### PR TITLE
Corrections to API Spec

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,54 +15,12 @@ paths:
         - v1
       summary: Get all registered webhooks
       parameters:
-        - name: Merchant-Serial-Number
-          in: header
-          required: true
-          style: simple
-          schema:
-            type: string
-        - name: Vipps-System-Name
-          in: header
-          description: |-
-            The name of the ecommerce solution.
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: woocommerce
-        - name: Vipps-System-Version
-          in: header
-          description: |-
-            The version number of the ecommerce solution.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '5.4.0'
-        - name: Vipps-System-Plugin-Name
-          in: header
-          description: |-
-            The name of the ecommerce plugin (if applicable).
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: vipps-woocommerce
-        - name: Vipps-System-Plugin-Version
-          in: header
-          description: |-
-            The version number of the ecommerce plugin (if applicable).
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '1.2.1'
+        - $ref: '#/components/parameters/APIM-Subscription-Key'
+        - $ref: '#/components/parameters/Merchant-Serial-Number'
+        - $ref: '#/components/parameters/Vipps-System-Name'
+        - $ref: '#/components/parameters/Vipps-System-Version'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
       responses:
         '200':
           description: Success
@@ -82,54 +40,12 @@ paths:
       summary: Register webhook
       description: 'At most 5 webhooks can currently be registered per event, please reach out if a higher limit is required.'
       parameters:
-        - name: Merchant-Serial-Number
-          in: header
-          required: true
-          style: simple
-          schema:
-            type: string
-        - name: Vipps-System-Name
-          in: header
-          description: |-
-            The name of the ecommerce solution.
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: woocommerce
-        - name: Vipps-System-Version
-          in: header
-          description: |-
-            The version number of the ecommerce solution.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '5.4.0'
-        - name: Vipps-System-Plugin-Name
-          in: header
-          description: |-
-            The name of the ecommerce plugin (if applicable).
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: vipps-woocommerce
-        - name: Vipps-System-Plugin-Version
-          in: header
-          description: |-
-            The version number of the ecommerce plugin (if applicable).
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '1.2.1'
+        - $ref: '#/components/parameters/APIM-Subscription-Key'
+        - $ref: '#/components/parameters/Merchant-Serial-Number'
+        - $ref: '#/components/parameters/Vipps-System-Name'
+        - $ref: '#/components/parameters/Vipps-System-Version'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
       requestBody:
         content:
           application/json:
@@ -149,6 +65,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+
   '/v1/webhooks/{id}':
     delete:
       tags:
@@ -162,54 +79,12 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: Merchant-Serial-Number
-          in: header
-          required: true
-          style: simple
-          schema:
-            type: string
-        - name: Vipps-System-Name
-          in: header
-          description: |-
-            The name of the ecommerce solution.
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: woocommerce
-        - name: Vipps-System-Version
-          in: header
-          description: |-
-            The version number of the ecommerce solution.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '5.4.0'
-        - name: Vipps-System-Plugin-Name
-          in: header
-          description: |-
-            The name of the ecommerce plugin (if applicable).
-            One word in lowercase letters is good.
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: vipps-woocommerce
-        - name: Vipps-System-Plugin-Version
-          in: header
-          description: |-
-            The version number of the ecommerce plugin (if applicable).
-            See [HTTP headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
-          style: simple
-          schema:
-            maxLength: 30
-            type: string
-            example: '1.2.1'
+        - $ref: '#/components/parameters/APIM-Subscription-Key'
+        - $ref: '#/components/parameters/Merchant-Serial-Number'
+        - $ref: '#/components/parameters/Vipps-System-Name'
+        - $ref: '#/components/parameters/Vipps-System-Version'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
       responses:
         '204':
           description: No Content
@@ -300,8 +175,8 @@ components:
             type: string
           description: 'See [Webhooks API Events](https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/events/) for details.'
           example:
-            - service.payment.captured.v1
-            - service.payment.created.v2
+            - epayments.payment.captured.v1
+            - epayments.payment.created.v1
       additionalProperties: false
     RegisterResponse:
       required:
@@ -335,6 +210,63 @@ components:
           items:
             type: string
           example:
-            - service.payment.captured.v1
-            - service.payment.created.v2
+            - epayments.payment.captured.v1
+            - epayments.payment.created.v1
       additionalProperties: false
+  parameters:
+    Merchant-Serial-Number:
+      name: Merchant-Serial-Number
+      in: header
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]{4,6}$'
+        minLength: 4
+        maxLength: 6
+        example: '123456'
+      description: "The Sales unit's MSN: The unique identifier for the sales unit."
+    APIM-Subscription-Key:
+      name: Ocp-Apim-Subscription-Key
+      in: header
+      required: true
+      schema:
+        type: string
+        example: da7d5b0e18a84aeda961c0c31b75c2a9
+      description: APIM Subscription Key
+    Vipps-System-Name:
+      name: Vipps-System-Name
+      in: header
+      description: The name of the ecommerce solution. One word in lowercase letters is good.
+      schema:
+        type: string
+        example: woocommerce
+    Vipps-System-Version:
+      name: Vipps-System-Version
+      in: header
+      description: The version number of the ecommerce solution.
+      schema:
+        type: string
+        example: '5.4.0'
+    Vipps-System-Plugin-Name:
+      name: Vipps-System-Plugin-Name
+      in: header
+      description: The name of the ecommerce plugin (if applicable). One word in lowercase letters is good.
+      schema:
+        type: string
+      example: "vipps-woocommerce"
+    Vipps-System-Plugin-Version:
+      name: Vipps-System-Plugin-Version
+      in: header
+      description: The version number of the ecommerce plugin (if applicable).
+      schema:
+        type: string
+        example: "1.2.1"
+  securitySchemes:
+    Bearer-Authorization:
+      name: Authorization
+      type: apiKey
+      in: header
+      description: Access bearer token (JWT)
+
+security:
+  - Bearer-Authorization: []


### PR DESCRIPTION
- Add Ocp-Apim-Subscription-Key as required header
- Add Authorization bearer token as required auth
- Fix example events that don't exist
- Refactor headers to be reusable in spec