### PR TITLE
Added Authorization header for relevant calls

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -40,9 +40,10 @@ For this quick start, you'll need the following.
 
 <TabItem value="postman">
 
-**Please note:** Postman is discontinuing their offline version. Use only your test keys and delete them after testing. Ensure that your company allows for cloud use before continuing.
+**Please note:** To prevent your sensitive data and credentials from being synced to the Postman cloud,
+store them in the *Current Value* fields of your Postman environment.
 
-To use Postman, import the following files:
+Import the following files:
 
 Remember to replace the placeholder values with your own credentials and callback URL.
 

--- a/quick-start.md
+++ b/quick-start.md
@@ -119,8 +119,7 @@ Send request 'Register'
 
 ```bash
 curl https://apitest.vipps.no/webhooks/v1/webhooks \
--H "client_id: YOUR-CLIENT-ID" \
--H "client_secret: YOUR-CLIENT-SECRET" \
+-H "Authorization: Bearer YOUR-ACCESS-TOKEN" \
 -H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
 -H "Merchant-Serial-Number: 123456" \
 -H "Vipps-System-Name: acme" \
@@ -156,8 +155,7 @@ Send request 'Get All'
 
 ```bash
 curl https://apitest.vipps.no/webhooks/v1/webhooks \
--H "client_id: YOUR-CLIENT-ID" \
--H "client_secret: YOUR-CLIENT-SECRET" \
+-H "Authorization: Bearer YOUR-ACCESS-TOKEN" \
 -H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
 -H "Merchant-Serial-Number: 123456" \
 -H "Vipps-System-Name: acme" \
@@ -192,8 +190,7 @@ Send request 'Delete Last'
 
 ```bash
 curl https://apitest.vipps.no/webhooks/v1/webhooks/<WEBHOOK-ID> \
--H "client_id: YOUR-CLIENT-ID" \
--H "client_secret: YOUR-CLIENT-SECRET" \
+-H "Authorization: Bearer YOUR-ACCESS-TOKEN" \
 -H "Ocp-Apim-Subscription-Key: YOUR-SUBSCRIPTION-KEY" \
 -H "Merchant-Serial-Number: 123456" \
 -H "Vipps-System-Name: acme" \


### PR DESCRIPTION
We only need to send along the clientId and clientSecret for the access token, for the rest the access_token is used instead