### PR TITLE
Chore: align examples and use raw string

### DIFF
--- a/request-authentication.md
+++ b/request-authentication.md
@@ -39,13 +39,11 @@ const dateTime = "Thu, 30 Mar 2023 08:38:32 GMT"
 // Part of the HTTP request header from Vipps MobilePay, found in the field 'authorization'
 const actualSignature = "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=agAiSyogQbDHpeucoNwYz+yAr5nJ+v+zasdkSbqzv+U="
 
-const httpBody = {
-  "some-unique-content":"ee6e441b-cc4a-46f8-895d-a5af79bcc233/hello-world"
-}
+const httpBody = '{"some-unique-content":"ee6e441b-cc4a-46f8-895d-a5af79bcc233/hello-world"}';
 
 const hashedPayload =  crypto
   .createHash("sha256")
-  .update(JSON.stringify(httpBody))
+  .update(httpBody)
   .digest("base64") // evaluates to 'lNlsp1XA03N34HrQsVzPgJKtC+r7l/RBF4V3JQUWMj4='
 
 const url = new URL(requestUrl)


### PR DESCRIPTION
### Issue

Current version could be wrongly push readers to try and explicitly deserialize then serialize request content which could cause confusion and wrong validation due to different serialization settings such as whitespace handling.

### Solution

Just assume body is already a string and remove the reference to JSON.stringify